### PR TITLE
Add options, and features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,7 @@ dependencies = [
  "expect-exit",
  "git2",
  "tempfile",
+ "thiserror",
 ]
 
 [[package]]
@@ -339,6 +340,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,6 +394,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,6 +416,26 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -417,6 +467,12 @@ name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775c11906edafc97bc378816b94585fbd9a054eabaf86fdd0ced94af449efab7"
 
 [[package]]
 name = "unicode-normalization"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,49 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "anyhow"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "bitflags"
@@ -37,27 +70,36 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "console"
-version = "0.14.1"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
+checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "regex",
- "terminal_size",
  "unicode-width",
- "winapi",
+ "windows-sys",
+]
+
+[[package]]
+name = "ctrlc"
+version = "3.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1631ca6e3c59112501a9d87fd86f21591ff77acd31331e8a73f8d80a65bbdd71"
+dependencies = [
+ "nix",
+ "windows-sys",
 ]
 
 [[package]]
 name = "dialoguer"
-version = "0.8.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9dd058f8b65922819fabb4a41e7d1964e56344042c26efbccd465202c23fa0c"
+checksum = "af3c796f3b0b408d9fd581611b47fa850821fcb84aa640b83a3c1a5be2d691f2"
 dependencies = [
  "console",
- "lazy_static",
+ "fuzzy-matcher",
+ "shell-words",
  "tempfile",
  "zeroize",
 ]
@@ -93,10 +135,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
+name = "gimli"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "221996f774192f0f718773def8201c4ae31f02616a54ccfc2d358bb0e5cefdec"
+
+[[package]]
 name = "git-select-branch"
 version = "0.1.3"
 dependencies = [
  "anyhow",
+ "ctrlc",
  "dialoguer",
  "expect-exit",
  "git2",
@@ -154,9 +212,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libgit2-sys"
@@ -208,6 +266,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "static_assertions",
+]
+
+[[package]]
+name = "object"
+version = "0.30.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,21 +348,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
-dependencies = [
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
-
-[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +355,24 @@ checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "tempfile"
@@ -286,13 +389,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "terminal_size"
-version = "0.1.16"
+name = "thread_local"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ca8ced750734db02076f44132d802af0b33b09942331f4459dde8636fd2406"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
- "libc",
- "winapi",
+ "once_cell",
 ]
 
 [[package]]
@@ -369,6 +471,63 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,11 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.68"
-dialoguer = "0.8.0"
+dialoguer = {version = "0.10.2", features = ["fuzzy-select"]}
+anyhow = {version = "1.0.68", features = ["backtrace"]}
 expect-exit = "0.5.2"
 git2 = "0.16.0"
+ctrlc = "3.2.4"
+
+[dev-dependencies]
 tempfile = "3.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = {version = "1.0.68", features = ["backtrace"]}
 expect-exit = "0.5.2"
 git2 = "0.16.0"
 ctrlc = "3.2.4"
+thiserror = "1.0.38"
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ cd git-select-branch
 cargo install --path .
 ```
 
+## Configuration
+
+### 
+
 ## Git alias
 
 Add the following section to your `~/.gitconfig`:

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,7 +73,7 @@ impl Config {
             }
             config.limit = Some(
                 usize::try_from(limit)
-                    .with_context(|| format!("Can't convert {:?} to usize", limit))?,
+                    .with_context(|| format!("Can't convert {limit:?} to usize"))?,
             )
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,93 @@
+use anyhow::{anyhow, Context};
+use dialoguer::theme::{ColorfulTheme, Theme};
+use std::convert::TryFrom;
+use std::sync::Arc;
+use std::usize;
+
+#[derive(Clone)]
+pub struct Config {
+    pub theme: Arc<dyn Theme>,
+    pub fuzzy: bool,
+    pub show_remote_branches: bool,
+    pub limit: Option<usize>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            theme: Arc::new(ColorfulTheme::default()),
+            fuzzy: true,
+            show_remote_branches: false,
+            limit: Some(20usize),
+        }
+    }
+}
+
+macro_rules! extract_config_value {
+    ($config:ident, bool, $option_name:expr) => {
+        map_git2_not_found_to_none($config.get_bool($option_name))
+            .with_context(|| format!("Error parsing boolean value in {}", $option_name))?
+    };
+
+    ($config:ident, str, $option_name:expr) => {
+        map_git2_not_found_to_none($config.get_str($option_name))
+            .with_context(|| format!("Error parsing string value in {}", $option_name))?
+    };
+
+    ($config:ident, i64, $option_name:expr) => {
+        map_git2_not_found_to_none($config.get_i64($option_name))
+            .with_context(|| format!("Error parsing integer value in {}", $option_name))?
+    };
+}
+
+impl Config {
+    pub fn from_git_config(git_config: &git2::Config) -> anyhow::Result<Config> {
+        let mut config = Config::default();
+        if let Some(value) = extract_config_value!(git_config, bool, "select-branch.fuzzy") {
+            config.fuzzy = value;
+        }
+
+        if let Some(value) =
+            extract_config_value!(git_config, bool, "select-branch.show-remote-branches")
+        {
+            config.show_remote_branches = value;
+        }
+
+        if let Some(value) = extract_config_value!(git_config, str, "select-branch.theme") {
+            config.theme = crate::match_theme_config(value)
+                .with_context(|| "Could not parse theme configuration")?;
+        }
+
+        if let Some("none") = extract_config_value!(git_config, str, "select-branch.limit") {
+            config.limit = None
+        } else if let Some(limit) = extract_config_value!(git_config, i64, "select-branch.limit") {
+            if limit <= 0 {
+                return Err(anyhow!(
+                    "\"{}\" is not a valid \"select-branch.limit\" value.\n\
+                    The value must be either a positive integer, or \"none\". e.g.:\n\
+                    > git config --global select-branch.limit none\n\
+                    or\n\
+                    > git config --global select-branch.limit 20",
+                    limit
+                ));
+            }
+            config.limit = Some(
+                usize::try_from(limit)
+                    .with_context(|| format!("Can't convert {:?} to usize", limit))?,
+            )
+        }
+
+        Ok(config)
+    }
+}
+
+fn map_git2_not_found_to_none<E>(
+    config_result: anyhow::Result<E, git2::Error>,
+) -> Result<Option<E>, git2::Error> {
+    config_result
+        .map(|value| Some(value))
+        .or_else(|err| match err.code() {
+            git2::ErrorCode::NotFound => Ok(None),
+            _ => Err(err),
+        })
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ pub enum SelectBranchError {
 fn run_tui() -> Result<()> {
     let current_dir = env::current_dir().or_exit_("Could not get current directory");
     let repo = Repository::discover(current_dir.as_path())
-        .or_exit_(format!("No git repository discovered at {:?}", current_dir).as_str());
+        .or_exit_(format!("No git repository discovered at {current_dir:?}").as_str());
 
     let git_config = repo
         .config()
@@ -117,7 +117,7 @@ fn match_theme_config(theme_name: &str) -> Result<Arc<dyn Theme>> {
 }
 
 fn checkout(repo: Repository, branch_name: &String) -> Result<()> {
-    let ref_name = format!("refs/heads/{}", branch_name);
+    let ref_name = format!("refs/heads/{branch_name}");
 
     let branch_object = repo.revparse_single(ref_name.as_str())?;
 
@@ -205,6 +205,7 @@ mod tests {
     use crate::config::Config;
     use crate::test::RepoFixture;
     use crate::{get_branch_options, get_sorted_branches};
+    use git2::SubmoduleUpdate::Default;
 
     #[test]
     fn test_get_sorted_branches() {
@@ -224,8 +225,10 @@ mod tests {
         fixture.create_branch("b", 20).unwrap();
         fixture.create_branch("c", 5).unwrap();
         fixture.create_remote_branch("origin", "d", 30).unwrap();
-        let mut config = Config::default();
-        config.show_remote_branches = true;
+        let config = Config {
+            show_remote_branches: true,
+            ..Default::default()
+        };
         let sorted_branches = get_sorted_branches(&config, &fixture.repo);
         assert_eq!(sorted_branches.unwrap(), vec!["origin/d", "b", "a", "c"])
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,12 @@
-use std::env;
+extern crate core;
 
-use anyhow::Result;
-use dialoguer::{theme::ColorfulTheme, Select};
+use std::convert::TryFrom;
+use std::io::ErrorKind;
+use std::{env, usize};
+
+use anyhow::{anyhow, Context, Result};
+use dialoguer::theme::{ColorfulTheme, SimpleTheme, Theme};
+use dialoguer::{FuzzySelect, Select};
 use expect_exit::Expected;
 use git2::{BranchType, Commit, Reference, Repository};
 
@@ -11,34 +16,81 @@ fn main() -> Result<()> {
     let repo = Repository::discover(current_dir.as_path())
         .or_exit_(format!("No git repository discovered at {:?}", current_dir).as_str());
 
-    let current_branch_owned = get_current_branch(&repo)?;
-    let current_branch = current_branch_owned;
-    let sorted_branches = get_sorted_branches(&repo)?;
+    let git_config = repo
+        .config()
+        .with_context(|| "Could not get git config")?
+        .snapshot()
+        .with_context(|| "Could not create a snapshot of git config")?;
+    let config = Config::from_git_config(&git_config)
+        .with_context(|| "Error reading configuration from git")?;
+
+    let current_branch = get_current_branch(&repo)?;
+    let sorted_branches = get_sorted_branches(&config, &repo)?;
     let options = get_branch_options(
         sorted_branches.iter().map(|s| s.as_str()).collect(),
         current_branch.as_deref(),
     );
 
-    let result = Select::with_theme(&ColorfulTheme::default())
-        .items(&options)
-        .paged(true)
-        .default(0)
-        .with_prompt("Which branch would you like to switch to?")
-        .interact_opt()
-        .expect("No selection");
+    ctrlc::set_handler(move || {
+        dialoguer_reset_cursor_hack();
+    })?;
 
-    match result {
-        Some(selection) => {
-            let selected_branch = &options[selection];
-            checkout(repo, selected_branch)?;
-        }
-        None => match current_branch {
-            Some(branch) => println!("Stayed on branch '{}'", &branch),
-            None => println!("Doing nothing"),
+    let prompt_result = match config.fuzzy {
+        true => FuzzySelect::with_theme(config.theme.as_ref())
+            .items(&options)
+            .default(0)
+            .with_prompt("Which branch would you like to switch to?")
+            .interact_opt()
+            .with_context(|| "Prompt interrupted"),
+        false => Select::with_theme(config.theme.as_ref())
+            .items(&options)
+            .default(0)
+            .with_prompt("Which branch would you like to switch to?")
+            .interact_opt()
+            .with_context(|| "Prompt interrupted"),
+    };
+
+    match prompt_result {
+        Ok(option) => match option {
+            Some(selection) => {
+                let selected_branch = &options[selection];
+                checkout(repo, selected_branch)?;
+                Ok(())
+            }
+            None => Err(anyhow!("Aborted.")),
+        },
+        // If err, figure out if it was a SIGINT and ...
+        Err(err) => match err.downcast_ref::<std::io::Error>() {
+            Some(io_err) => match io_err.kind() {
+                // ... if so replace err with a shorter version.
+                ErrorKind::Interrupted => Err(anyhow!("Interrupted")),
+                _ => Err(err),
+            },
+            None => Err(err),
         },
     }
+}
 
-    Ok(())
+/// `dialoguer` doesn't clean up your term if it's aborted via e.g. `SIGINT` or other exceptions:
+/// https://github.com/console-rs/dialoguer/issues/188.
+///
+/// `dialoguer`, as a library, doesn't want to mess with signal handlers,
+/// but we, as an application, are free to mess with signal handlers if we feel like it, since we
+/// own the process.
+fn dialoguer_reset_cursor_hack() {
+    let term = dialoguer::console::Term::stdout();
+    let _ = term.show_cursor();
+}
+
+fn match_theme_config(theme_name: &str) -> Result<Box<dyn Theme>> {
+    match theme_name {
+        "colorful" => Ok(Box::new(ColorfulTheme::default())),
+        "simple" => Ok(Box::new(SimpleTheme)),
+        value => Err(anyhow!(
+            "{} is not a valid theme, expected one of \"colorful\", \"simple\"",
+            value
+        )),
+    }
 }
 
 fn checkout(repo: Repository, branch_name: &String) -> Result<()> {
@@ -83,7 +135,7 @@ fn get_current_branch(repo: &Repository) -> Result<Option<String>> {
         .map(|s| s.to_string()))
 }
 
-fn get_sorted_branches(repo: &Repository) -> Result<Vec<String>> {
+fn get_sorted_branches(config: &Config, repo: &Repository) -> Result<Vec<String>> {
     let branch_refs: Vec<Reference> = repo
         .branches(Some(BranchType::Local))?
         .filter(|r| r.is_ok())
@@ -104,12 +156,11 @@ fn get_sorted_branches(repo: &Repository) -> Result<Vec<String>> {
     branch_name_and_commit.sort_by(|(_, a), (_, b)| a.time().partial_cmp(&b.time()).unwrap());
     branch_name_and_commit.reverse();
 
-    let branches = branch_name_and_commit
-        .iter()
-        .take(20)
-        .map(|(name, _)| name.to_string())
-        .collect();
-
+    let iter = branch_name_and_commit.iter();
+    let branches = match config.limit {
+        Some(limit) => iter.take(limit).map(|(name, _)| name.to_string()).collect(),
+        None => iter.map(|(name, _)| name.to_string()).collect(),
+    };
     Ok(branches)
 }
 
@@ -183,4 +234,75 @@ mod tests {
         let options = get_branch_options(vec!["a", "b", "c"], Some("c"));
         assert_eq!(options, vec!["c", "a", "b"])
     }
+}
+
+struct Config {
+    theme: Box<dyn Theme>,
+    fuzzy: bool,
+    limit: Option<usize>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            theme: Box::new(ColorfulTheme::default()),
+            fuzzy: false,
+            limit: Some(20usize),
+        }
+    }
+}
+
+impl Config {
+    fn from_git_config(git_config: &git2::Config) -> Result<Config> {
+        let mut config = Config::default();
+        if let Some(value) = map_git2_not_found_to_none(git_config.get_bool("select-branch.fuzzy"))
+            .with_context(|| "Error parsing select-branch.fuzzy")?
+        {
+            config.fuzzy = value;
+        }
+
+        if let Some(value) = map_git2_not_found_to_none(git_config.get_str("select-branch.theme"))
+            .with_context(|| "Error parsing select-branch.theme")?
+        {
+            config.theme =
+                match_theme_config(value).with_context(|| "Could not parse theme configuration")?;
+        }
+
+        if let Some("none") = map_git2_not_found_to_none(git_config.get_str("select-branch.limit"))
+            .with_context(|| "Error parsing select-branch.limit")?
+        {
+            config.limit = None
+        } else if let Some(limit) =
+            map_git2_not_found_to_none(git_config.get_i64("select-branch.limit"))
+                .with_context(|| "Error parsing select-branch.limit")?
+        {
+            if limit <= 0 {
+                return Err(anyhow!(
+                    "\"{}\" is not a valid \"select-branch.limit\" value.\n\
+                    The value must be either a positive integer, or \"none\". e.g.:\n\
+                    > git config --global select-branch.limit none\n\
+                    or\n\
+                    > git config --global select-branch.limit 20",
+                    limit
+                ));
+            }
+            config.limit = Some(
+                usize::try_from(limit)
+                    .with_context(|| format!("Can't convert {:?} to usize", limit))?,
+            )
+        }
+
+        Ok(config)
+    }
+}
+
+fn map_git2_not_found_to_none<E>(
+    config_result: Result<E, git2::Error>,
+) -> core::result::Result<Option<E>, git2::Error> {
+    config_result
+        .map(|value| Some(value))
+        .or_else(|err| match err.code() {
+            git2::ErrorCode::NotFound => Ok(None),
+            _ => Err(err),
+        })
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -43,10 +43,10 @@ impl RepoFixture {
         let tree = self.repo.find_tree(tree_id)?;
 
         let _ = self.repo.commit(
-            Some(format!("refs/heads/{}", name).as_str()),
+            Some(format!("refs/heads/{name}").as_str()),
             &signature,
             &signature,
-            format!("commit at {:?}", time).as_str(),
+            format!("commit at {time:?}").as_str(),
             &tree,
             &[],
         )?;
@@ -70,10 +70,10 @@ impl RepoFixture {
         let tree = self.repo.find_tree(tree_id)?;
 
         let _ = self.repo.commit(
-            Some(format!("refs/remotes/{}/{}", remote_name, name).as_str()),
+            Some(format!("refs/remotes/{remote_name}/{name}").as_str()),
             &signature,
             &signature,
-            format!("commit at {:?}", time).as_str(),
+            format!("commit at {time:?}").as_str(),
             &tree,
             &[],
         )?;

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use git2::{Repository, RepositoryInitOptions, Signature, Time};
 
-use crate::config::Config;
 use tempfile::TempDir;
 
 pub fn repo_init() -> (TempDir, Repository) {
@@ -19,26 +18,17 @@ pub fn repo_init() -> (TempDir, Repository) {
 
 #[derive()]
 pub struct RepoFixture {
-    tempdir: TempDir,
-    repo: Repository,
+    pub _tempdir: TempDir,
+    pub repo: Repository,
 }
 
 impl RepoFixture {
     pub fn new() -> Self {
         let (tempdir, repo) = repo_init();
-        Self { tempdir, repo }
-    }
-
-    pub fn tempdir(&self) -> &TempDir {
-        &self.tempdir
-    }
-
-    pub fn repo(&self) -> &Repository {
-        &self.repo
-    }
-
-    pub fn config(&self) -> Result<Config> {
-        Ok(Config::from_git_config(&self.repo.config()?.snapshot()?)?)
+        Self {
+            _tempdir: tempdir,
+            repo,
+        }
     }
 
     pub fn create_branch(&self, name: &str, commit_time_seconds: i64) -> Result<()> {

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,7 @@
-use git2::{Repository, RepositoryInitOptions};
+use anyhow::Result;
+use git2::{Repository, RepositoryInitOptions, Signature, Time};
+
+use crate::config::Config;
 use tempfile::TempDir;
 
 pub fn repo_init() -> (TempDir, Repository) {
@@ -10,13 +13,80 @@ pub fn repo_init() -> (TempDir, Repository) {
         let mut config = repo.config().unwrap();
         config.set_str("user.name", "name").unwrap();
         config.set_str("user.email", "email").unwrap();
-        let mut index = repo.index().unwrap();
-        let id = index.write_tree().unwrap();
-
-        let tree = repo.find_tree(id).unwrap();
-        let sig = repo.signature().unwrap();
-        repo.commit(Some("HEAD"), &sig, &sig, "initial\n\nbody", &tree, &[])
-            .unwrap();
     }
     (td, repo)
+}
+
+#[derive()]
+pub struct RepoFixture {
+    tempdir: TempDir,
+    repo: Repository,
+}
+
+impl RepoFixture {
+    pub fn new() -> Self {
+        let (tempdir, repo) = repo_init();
+        Self { tempdir, repo }
+    }
+
+    pub fn tempdir(&self) -> &TempDir {
+        &self.tempdir
+    }
+
+    pub fn repo(&self) -> &Repository {
+        &self.repo
+    }
+
+    pub fn config(&self) -> Result<Config> {
+        Ok(Config::from_git_config(&self.repo.config()?.snapshot()?)?)
+    }
+
+    pub fn create_branch(&self, name: &str, commit_time_seconds: i64) -> Result<()> {
+        let time = Time::new(commit_time_seconds, 0);
+        let default_signature = self.repo.signature()?;
+        let signature = Signature::new(
+            default_signature.name().unwrap(),
+            default_signature.email().unwrap(),
+            &time,
+        )?;
+        let tree_id = self.repo.index()?.write_tree()?;
+        let tree = self.repo.find_tree(tree_id)?;
+
+        let _ = self.repo.commit(
+            Some(format!("refs/heads/{}", name).as_str()),
+            &signature,
+            &signature,
+            format!("commit at {:?}", time).as_str(),
+            &tree,
+            &[],
+        )?;
+        Ok(())
+    }
+
+    pub fn create_remote_branch(
+        &self,
+        remote_name: &str,
+        name: &str,
+        commit_time_seconds: i64,
+    ) -> Result<()> {
+        let time = Time::new(commit_time_seconds, 0);
+        let default_signature = self.repo.signature()?;
+        let signature = Signature::new(
+            default_signature.name().unwrap(),
+            default_signature.email().unwrap(),
+            &time,
+        )?;
+        let tree_id = self.repo.index()?.write_tree()?;
+        let tree = self.repo.find_tree(tree_id)?;
+
+        let _ = self.repo.commit(
+            Some(format!("refs/remotes/{}/{}", remote_name, name).as_str()),
+            &signature,
+            &signature,
+            format!("commit at {:?}", time).as_str(),
+            &tree,
+            &[],
+        )?;
+        Ok(())
+    }
 }


### PR DESCRIPTION
with the power of `git2` we can add lots of configurable options through
git's config files!

I started with these:

- `select-branch.theme`: `"colorful" | "simple"`
- `select-branch.limit`: `1..usize::MAX | "none"`
- `select-branch.fuzzy`: `"true" | "false"`

as well as implement the things that change based on those configuration
options.

I also made an attempt to work around the issue described in
https://github.com/console-rs/dialoguer/issues/188, the workaround isn't
perfect, but making it more perfect might require modifying the way
`term.read_key()`'s `Err` case is handled in e.g.:
- https://github.com/console-rs/dialoguer/blob/f6f6e260142e30d2f750a0f25e76191a6a0e4223/src/prompts/select.rs#L275 and
- https://github.com/console-rs/dialoguer/blob/f6f6e260142e30d2f750a0f25e76191a6a0e4223/src/prompts/fuzzy_select.rs#L225